### PR TITLE
update README with several error find in WSL env

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,12 @@ sudo apt-get update
 3. This commands rips of the Docker container build command to install all the dependent packages.
 ````sh
 sudo apt-get install -y $(
-  sed -n '/apt-get install/,/apt-get clean/p' Dockerfile \
+  awk '/apt-get install/,/apt-get clean/' Dockerfile \
   | tail -n+2 | head -n-1 \
-  | sed -e 's/\r$//' -e 's/\\$//' -e 's/^[[:space:]]*//' \
-  | grep -v '^[[:space:]]*$'
+  | tr -d '\r' \
+  | sed -e 's/\\$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+  | grep -v '^$' \
+  | tr '\n' ' '
 )
 ````
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,26 @@ sudo apt-get update
 
 3. This commands rips of the Docker container build command to install all the dependent packages.
 ````sh
-sudo apt-get install -y $(sed -n '/apt-get install/,/apt-get clean/p' Dockerfile | tail -n+2 | head -n-1 | sed 's/\\//')
+sudo apt-get install -y $(
+  sed -n '/apt-get install/,/apt-get clean/p' Dockerfile \
+  | tail -n+2 | head -n-1 \
+  | sed -e 's/\r$//' -e 's/\\$//' -e 's/^[[:space:]]*//' \
+  | grep -v '^[[:space:]]*$'
+)
 ````
 
 4. Have this repo built from source.
+> make sure you are using zsh
 ````sh
+zsh
 source setup.sh
 source init.sh
 ````
+
+If you encounter an error such as `Error 1 g++: fatal error: Killed signal terminated program cc1plus compilation terminated.`, it likely means your machine is out of memory (OOM). In this case, try replacing all `make -j` commands in the scripts referenced by [`init.sh`](./init.sh) with `make -j4` or a lower parallelism value to reduce memory usage.
+
+
+
 
 5. Verify your installation.
 ````sh

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ sudo apt-get update
 ````sh
 sudo apt-get install -y $(
   awk '/apt-get install/,/apt-get clean/' Dockerfile \
-  | tail -n+2 | head -n-1 \
-  | tr -d '\r' \
-  | sed -e 's/\\$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+  | sed '1d;$d; s/[\\[:space:]]*$//; s/^[[:space:]]*//' \
   | grep -v '^$' \
   | tr '\n' ' '
 )


### PR DESCRIPTION
1. For file in windows env, nextline is composed of \r\n ，and sed commond may process \r incorrectly. 
2. For user with little memory like 16G, make -j command will lead to OOM, and the init.sh process will be killed.