### PR TITLE
[document] add four markdown files docuing codes in codegen/simulator…

### DIFF
--- a/python/assassyn/codegen/simulator/_expr/arith.md
+++ b/python/assassyn/codegen/simulator/_expr/arith.md
@@ -1,0 +1,31 @@
+# Arithmetic Code Generation Module
+
+This module provides helper functions to generate simulator code for arithmetic operations. It translates Intermediate Representation (IR) nodes for arithmetic into Rust code expressions for the simulator backend.
+
+-----
+
+## Exposed Interfaces
+
+```python
+def codegen_binary_op(node: BinaryOp, module_ctx, sys) -> str
+def codegen_unary_op(node: UnaryOp, module_ctx, sys) -> str
+```
+
+-----
+
+## Binary Operation Generation
+
+The `codegen_binary_op` function generates a Rust expression for a `BinaryOp` IR node.
+
+  * **Process**: The function maps the node's opcode to the corresponding Rust operator (e.g., `+`, `-`, `&`). It generates the code for the left and right-hand side operands and casts them to the appropriate Rust type.
+  * **Generated Code Structure**: `(<lhs>) <op> (<rhs>)`
+  * **Special Handling**: For signed right-shift operations (`SHR`), it explicitly casts operands to a signed integer type in Rust (like `i64`) to ensure an arithmetic, rather than logical, shift is performed.
+
+-----
+
+## Unary Operation Generation
+
+The `codegen_unary_op` function generates a Rust expression for a `UnaryOp` IR node.
+
+  * **Process**: It maps the node's opcode to a Rust operator (e.g., `FLIP` becomes `!`) and prepends it to the generated code for the operand.
+  * **Generated Code Structure**: `<op>(<operand>)`

--- a/python/assassyn/codegen/simulator/_expr/array.md
+++ b/python/assassyn/codegen/simulator/_expr/array.md
@@ -1,0 +1,35 @@
+# Array Code Generation Module
+
+This module provides helper functions to generate Rust code for array read and write operations for the simulator backend.
+
+-----
+
+## Exposed Interfaces
+
+```python
+def codegen_array_read(node, module_ctx, sys) -> str
+def codegen_array_write(node, module_ctx, sys, module_name) -> str
+```
+
+-----
+
+## Array Read Generation
+
+The `codegen_array_read` function generates a Rust expression to read from an array by accessing its `payload` field at a given index.
+
+  * **Generated Code**: `sim.<array_name>.payload[<index> as usize].clone()`
+
+-----
+
+## Array Write Generation
+
+The `codegen_array_write` function generates a Rust code block to write to an array. It pushes a timestamped `ArrayWrite` object-containing the value, index, and writer's info-onto the array's `write_port`.
+
+  * **Generated Code**:
+    ```rust
+    {
+        let stamp = sim.stamp - sim.stamp % 100 + 50;
+        sim.<array_name>.write_port.push(
+          ArrayWrite::new(stamp, <index> as usize, <value>.clone(), "<module_name>", <port_id>));
+    }
+    ```

--- a/python/assassyn/codegen/simulator/_expr/call.md
+++ b/python/assassyn/codegen/simulator/_expr/call.md
@@ -1,0 +1,67 @@
+# Call Operation Code Generation
+
+This module generates Rust code for call-related IR nodes, such as asynchronous calls and FIFO manipulations, for the simulator backend.
+
+-----
+
+## Exposed Interfaces
+
+```python
+def codegen_async_call(node: AsyncCall, module_ctx, sys) -> str
+def codegen_fifo_pop(node: FIFOPop, module_ctx, sys, module_name) -> str
+def codegen_fifo_push(node: FIFOPush, module_ctx, sys, module_name) -> str
+def codegen_bind(node: Bind, module_ctx, sys) -> str
+```
+
+-----
+
+## Async Call Generation
+
+`codegen_async_call` schedules an asynchronous event by pushing a future timestamp onto the callee's event queue.
+
+  * **Generated Code**:
+    ```rust
+    {
+        let stamp = sim.stamp - sim.stamp % 100 + 100;
+        sim.<callee_name>_event.push_back(stamp)
+    }
+    ```
+
+-----
+
+## FIFO Pop Generation
+
+`codegen_fifo_pop` requests a value from a FIFO. It logs a pop event and tries to retrieve the item, returning `false` if the FIFO is empty.
+
+  * **Generated Code**:
+    ```rust
+    {
+        let stamp = sim.stamp - sim.stamp % 100 + 50;
+        sim.<fifo_id>.pop.push(FIFOPop::new(stamp, "<module_name>"));
+        match sim.<fifo_id>.payload.front() {
+          Some(value) => value.clone(),
+          None => return false,
+        }
+    }
+    ```
+
+-----
+
+## FIFO Push Generation
+
+`codegen_fifo_push` adds a timestamped push request, containing the value, to the target FIFO's `push` queue.
+
+  * **Generated Code**:
+    ```rust
+    {
+        let stamp = sim.stamp;
+        sim.<fifo_id>.push.push(
+          FIFOPush::new(stamp + 50, <value>.clone(), "<module_name>"));
+    }
+    ```
+
+-----
+
+## Bind Operation Generation
+
+`codegen_bind` is a no-op for simulation, returning the Rust unit type `()`.

--- a/python/assassyn/codegen/simulator/_expr/intrinsics.md
+++ b/python/assassyn/codegen/simulator/_expr/intrinsics.md
@@ -1,0 +1,45 @@
+# Intrinsic Code Generation
+
+This module generates Rust code for two types of special operations: side-effect-free `PureIntrinsic` functions and side-effecting `Intrinsic` commands.
+
+-----
+
+## Exposed Interfaces
+
+```python
+def codegen_pure_intrinsic(node: PureIntrinsic, module_ctx, sys) -> str
+def codegen_intrinsic(node: Intrinsic, module_ctx, sys, ...) -> str
+```
+
+-----
+
+## Pure Intrinsics
+
+`codegen_pure_intrinsic` generates code for read-only operations that inspect the simulator state.
+
+  * **`FIFO_PEEK`**: Peeks the front value of a FIFO without removing it.
+      * **Generated Code**: `sim.<fifo>.front().cloned()`
+  * **`FIFO_VALID`**: Checks if a FIFO is not empty.
+      * **Generated Code**: `!sim.<fifo>.is_empty()`
+  * **`VALUE_VALID`**: Checks if a signal's value is valid (`Some`).
+      * **Generated Code**: `sim.<value>_value.is_some()`
+  * **`MODULE_TRIGGERED`**: Checks if a module was triggered in the current cycle.
+      * **Generated Code**: `sim.<module>_triggered`
+
+-----
+
+## Side-Effecting Intrinsics
+
+`codegen_intrinsic` generates code for commands that can change the simulator state or control flow.
+
+  * **`WAIT_UNTIL`**: Pauses the current module's execution until a condition is true.
+      * **Generated Code**: `if !<condition> { return false; }`
+  * **`FINISH`**: Terminates the entire simulation.
+      * **Generated Code**: `std::process::exit(0);`
+  * **`ASSERT`**: Asserts a runtime condition, causing a panic if it's false.
+      * **Generated Code**: `assert!(<condition>);`
+  * **`BARRIER`**: A no-op in generated code, used as a hint for compilation.
+  * **`SEND_READ_REQUEST` / `SEND_WRITE_REQUEST`**: Send a read or write request to the main memory interface.
+  * **`USE_DRAM`**: A configuration command that links a specific FIFO to receive DRAM read responses.
+  * **`HAS_MEM_RESP` / `MEM_RESP`**: Check for and retrieve a pending data response from the DRAM-linked FIFO.
+  * **`MEM_WRITE`**: Performs an array write operation specifically for DRAM.


### PR DESCRIPTION
in codegen/simulator/_expr, including arith.py, array.py, call.py and intrinsics.py.