### PR TITLE
[refactor] Separate module generation into individual files

### DIFF
--- a/python/assassyn/codegen/simulator/elaborate.py
+++ b/python/assassyn/codegen/simulator/elaborate.py
@@ -48,9 +48,9 @@ def elaborate_impl(sys, config):
     # Create rustfmt for the generated project
     shutil.copy(Path(repo_path()) / "rustfmt.toml", simulator_path / "rustfmt.toml")
 
-    # Generate modules.rs
-    with open(simulator_path / "src/modules.rs", 'w', encoding="utf-8") as fd:
-        dump_modules(sys, fd)
+    # Generate modules directory and files
+    modules_dir = simulator_path / "src" / "modules"
+    dump_modules(sys, modules_dir)
 
     # Generate simulator.rs
     with open(simulator_path / "src/simulator.rs", 'w', encoding='utf-8') as fd:

--- a/python/assassyn/codegen/simulator/simulator.py
+++ b/python/assassyn/codegen/simulator/simulator.py
@@ -97,6 +97,7 @@ def dump_simulator( #pylint: disable=too-many-locals, too-many-branches, too-man
     fd.write("use sim_runtime::*;\n")
     fd.write("use std::collections::VecDeque;\n")
     fd.write("use std::collections::HashMap;\n")
+    fd.write("use crate::modules;\n")
     platform_os = platform.system().lower()
     if platform_os == 'darwin':
         x = "use sim_runtime::libloading::os::unix::{Library, Symbol, RTLD_LAZY, RTLD_GLOBAL};\n"
@@ -248,7 +249,7 @@ def dump_simulator( #pylint: disable=too-many-locals, too-many-branches, too-man
             fd.write(f"    if {conds} {{\n")
 
         # Call module function and handle result
-        fd.write(f"      let succ = super::modules::{module_name}(self);\n")
+        fd.write(f"      let succ = modules::{module_name}::{module_name}(self);\n")
 
         if not isinstance(module, Downstream):
             # Pop event on success


### PR DESCRIPTION
- Modified dump_modules to create separate files for each module in modules/ directory
- Created modules/mod.rs for rust_callback and module declarations
- Updated elaborate.py to generate modules directory instead of single modules.rs file
- Fixed simulator.py imports and function calls to use new module structure
- Each module now has its own .rs file named after the module
- Added BigInt/BigUint imports to individual module files to fix compilation errors
- All tests pass successfully